### PR TITLE
feat(ci): add the changelog release manager

### DIFF
--- a/.github/workflows/action-deploy.yaml
+++ b/.github/workflows/action-deploy.yaml
@@ -14,24 +14,10 @@ jobs:
   Test:
     uses: ./.github/workflows/action-test.yaml
 
-  Strip_Version:
-    runs-on: ubuntu-latest
-    outputs:
-      CLEAN_TAG: ${{ steps.set-output.outputs.CLEAN_TAG }}
-    steps:
-      - name: Strip "v" from Tag
-        id: set-output
-        run: echo "CLEAN_TAG=${GITHUB_EVENT_RELEASE_TAG_NAME#v}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
-
   Publish:
+    name: 🚀 Publish to npm
     runs-on: ubuntu-latest
-    outputs:
-      GIT_BRANCH_TARGET: ${{ steps.set-npm-tag.outputs.GIT_BRANCH_TARGET }}
-    needs: ['Test', 'Strip_Version']
-    env:
-      CLEAN_TAG: ${{ needs.Strip_Version.outputs.CLEAN_TAG }}
+    needs: ['Test']
     steps:
       - name: Download the build artifact
         uses: actions/download-artifact@v8
@@ -45,16 +31,17 @@ jobs:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Update Version in Package.json
-        id: set-npm-tag
+      # The package.json version was already bumped on main by the Release
+      # Manager (job-version-bump). Derive the npm dist-tag from the release tag.
+      - name: Resolve npm dist-tag
+        id: npm-tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          npm version $CLEAN_TAG --no-git-tag-version
-          if [[ "$CLEAN_TAG" == *"beta"* ]]; then
-            echo "NPM_TAG=beta" >> $GITHUB_OUTPUT
-            echo "GIT_BRANCH_TARGET=develop" >> $GITHUB_OUTPUT
+          if [[ "$RELEASE_TAG" == *"beta"* ]]; then
+            echo "NPM_TAG=beta" >> "$GITHUB_OUTPUT"
           else
-            echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
-            echo "GIT_BRANCH_TARGET=main" >> $GITHUB_OUTPUT
+            echo "NPM_TAG=latest" >> "$GITHUB_OUTPUT"
           fi
 
       # OIDC trusted publishing + provenance require npm >= 11.5.1.
@@ -66,45 +53,8 @@ jobs:
       # No --token / NODE_AUTH_TOKEN: npm authenticates via the GitHub OIDC token
       # matched against the trusted publisher on npmjs.com.
       - name: Publish to npm
-        run: npm publish --provenance --access public --ignore-scripts --tag ${{ steps.set-npm-tag.outputs.NPM_TAG }}
-
-  Update_Repo:
-    runs-on: ubuntu-latest
-    needs: ['Test', 'Strip_Version', 'Publish']
-    permissions:
-      contents: write
-      actions: write
-      checks: write
-    env:
-      CLEAN_TAG: ${{ needs.Strip_Version.outputs.CLEAN_TAG }}
-      GIT_BRANCH_TARGET: ${{ needs.Publish.outputs.GIT_BRANCH_TARGET }}
-    steps:
-      # - uses: hmarr/debug-action@v3
-
-      - uses: actions/checkout@v4
-        with:
-          token: '${{ secrets.GITHUB_TOKEN }}'
-          ref: ${{ env.GIT_BRANCH_TARGET }}
-          sparse-checkout: |
-            package.json
-            CHANGELOG.md
-          sparse-checkout-cone-mode: false
-
-      - name: Update Version in Package.json
-        id: set-git-branch
-        run: npm version $CLEAN_TAG --no-git-tag-version
-
-      - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
-        with:
-          latest-version: ${{ github.event.release.name }}
-          release-notes: ${{ github.event.release.body }}
-
-      - name: Commit and Push Version Update
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "chore(release): ${{ github.event.release.tag_name }} [skip ci]"
+        run: npm publish --provenance --access public --ignore-scripts --tag ${{ steps.npm-tag.outputs.NPM_TAG }}
 
   Document:
-    needs: ['Update_Repo', 'Publish']
+    needs: ['Publish']
     uses: ./.github/workflows/action-docs.yaml

--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -1,0 +1,57 @@
+name: Release Manager
+# On push to main: anticipate the next version with release-drafter, bump
+# package.json to it, write it into CHANGELOG.md via the changelog action, and
+# commit that back as a [skip ci] pre-release commit. The maintainer then
+# MANUALLY publishes the GitHub Release (which creates the tag), and
+# action-deploy publishes to npm using the already-bumped package.json version.
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**.md']
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-manager:
+    name: 🚀 Update Changelog & Prep Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Release Drafter (anticipate version)
+        id: drafter
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump package.json version
+        run: npm version v${{ steps.drafter.outputs.resolved_version }} --no-git-tag-version
+
+      - name: Update CHANGELOG.md
+        uses: bugs5382/changelog-updater-action@v0.3.2
+        env:
+          LOG_LEVEL: debug
+          LOG_FORMAT: text
+        with:
+          tag: v${{ steps.drafter.outputs.resolved_version }}
+          notes: ${{ steps.drafter.outputs.body }}
+          path: .
+          diff: 'true'
+
+      - name: Commit and push changelog
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore(pre-release): v${{ steps.drafter.outputs.resolved_version }} [skip ci]"


### PR DESCRIPTION
## What and why

Add a "Release Manager" workflow so `CHANGELOG.md` is written and committed to `main` BEFORE the maintainer tags a release, matching the node-hl7 standard. Today the version bump and changelog happen DURING the release (the `Strip_Version` + `Update_Repo` jobs and `stefanzweifel/changelog-updater-action` in `action-deploy.yaml`), so the changelog lands after the tag. This moves both to `main`.

`.github/workflows/job-version-bump.yaml` (new): on push to main (`paths-ignore: ['**.md']`) it creates an app token, checks out with that token at `fetch-depth: 0`, anticipates the next version with release-drafter, bumps `package.json` (`npm version v${resolved} --no-git-tag-version` -- fastify-hl7 is an npm package, so it does bump, unlike the composite-action variant), appends the version section via `bugs5382/changelog-updater-action@v0.3.2`, and commits `chore(pre-release): v${resolved} [skip ci]`.

`action-deploy.yaml` reconciled: on `release: released` it runs Test then publishes to npm via OIDC (`npm publish --provenance --access public --ignore-scripts`, no NPM_TOKEN) using the already-bumped `package.json` version, deriving the npm dist-tag (beta/latest) from the release tag. Removed the `Strip_Version` and `Update_Repo` jobs and the in-release changelog step. Kept the `Document` (docs) job; it now depends only on `Publish` since `Update_Repo` is gone.

`CHANGELOG.md` already carries the `# Fastify HL7` top heading and the v3.x history; left intact. New `## vX - date` sections append under the heading.

Closes #90

## Verification

- [x] Lint clean
- [x] Tests pass
- [x] Build succeeds
- [x] Documentation updated (if behavior or API changed)

## How this was verified

- `npm run lint`, `npm run build`, `npm test` (39 tests) all pass locally.
- Validated both changed workflows: `ruby -ryaml -e "YAML.load_file(...)"` -> OK.
- pre-commit and governance pre-push hooks ran on commit/push and passed.

## Runtime setup required (not in this PR)

Same setup eslint-config needed for its `[skip ci]` push: the org `vars.APP_CLIENT_ID` / `secrets.APP_PRIVATE_KEY` must be present, and the release GitHub App must be added as a bypass actor on the branch ruleset, or the Release Manager's `[skip ci]` push to `main` will be blocked.

Base is `feat/node-hl7-v4` (NOT main) -- this is part of the 4.0.0 work (#88).

---

**Before merging:** add a closing comment summarizing what was actually done in this PR.