### PR TITLE
fix(ci): restore npm publish workflow (stable-only)

### DIFF
--- a/.github/workflows/action-deploy.yaml
+++ b/.github/workflows/action-deploy.yaml
@@ -1,0 +1,63 @@
+name: Release and Publish
+# Fires when the maintainer publishes a (stable) GitHub Release. By then the
+# Release Manager (job-version-bump.yaml) has already bumped package.json and
+# written CHANGELOG.md on main, so this only re-tests, publishes to npm via
+# OIDC, and republishes the docs. Stable-only: prereleases are not shipped, and
+# there is no manual-dispatch path that could publish off a release.
+on:
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  Test:
+    name: 🧪 Test
+    uses: ./.github/workflows/action-test.yaml
+
+  Publish:
+    name: 🚀 Publish
+    runs-on: ubuntu-latest
+    needs: [Test]
+    # id-token: write lets npm verify the OIDC token GitHub issues against the
+    # trusted publisher registered on npmjs.com -- no NPM_TOKEN.
+    steps:
+      - name: Download the build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: ./
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org/'
+
+      # OIDC trusted publishing + provenance require npm >= 11.5.1 (the LTS image
+      # ships 10.x).
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      # The version is already in package.json (set by the Release Manager).
+      # Idempotent: skip if that exact version is already on the registry
+      # (partial-publish retry).
+      - name: Publish to npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${NAME}@${VERSION} already published -- skipping."
+          else
+            npm publish --provenance --access public --ignore-scripts
+          fi
+
+  Document:
+    name: 📚 Publish Docs
+    needs: [Publish]
+    uses: ./.github/workflows/action-docs.yaml


### PR DESCRIPTION
## What
Restore `action-deploy.yaml` as a stable-only, release-triggered npm publish workflow (Test -> Publish -> Publish Docs).

## Why
#99 removed the incorrect version, which left no publish path on release. This restores it without the prior flaws: triggered only by `release: types: [released]`, no `workflow_dispatch` publish footgun, no beta dist-tag.

## Verification
- YAML parses.
- The version is already on `main` (Release Manager); publish reads it, ships to `latest` via OIDC + provenance, idempotent on retry.

Closes #100