### PR TITLE
fix(ci): correct release config and add a manual Release Manager trigger

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,56 +1,73 @@
+# Canonical release-drafter config for every Bugs5382 repo (libraries/extensions
+# use release-drafter; only apps would use release-please, which we do not ship).
+# The autolabeler derives the categorizing label from the conventional-commit PR
+# title, so labeling is near-zero-effort; job-label-checker is the backstop.
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 template: |
-  ## What Changed 👀
-  
+  # What Changed 👀
+
   $CHANGES
-  
+
   # Extra
-  
+
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
+  - title: 💥 Breaking Changes
+    labels: [breaking]
   - title: 🚀 Features
-    labels:
-      - feature
-      - enhancement
+    labels: [enhancement]
   - title: 🐛 Bug Fixes
-    labels:
-      - fix
-      - bug
+    labels: [bug, fix]
+  - title: ⚡ Performance
+    labels: [performance]
   - title: ⚠️ Changes
-    labels:
-      - changed
+    labels: [refactor, changed]
   - title: ⛔️ Deprecated
-    labels:
-      - deprecated
+    labels: [deprecated]
   - title: 🗑 Removed
-    labels:
-      - removed
+    labels: [removed]
   - title: 🔐 Security
-    labels:
-      - security
+    labels: [security]
   - title: 📄 Documentation
-    labels:
-      - docs
-      - documentation
+    labels: [documentation]
   - title: 🧩 Dependency Updates
-    labels:
-      - deps
-      - dependencies
+    labels: [dependencies]
     collapse-after: 5
-prerelease-identifier: 'beta'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&'
 version-resolver:
   major:
-    labels:
-      - major
+    labels: [breaking]
   minor:
-    labels:
-      - minor
+    labels: [enhancement]
   patch:
-    labels:
-      - patch
+    labels: [fix, bug, performance, refactor, changed, deprecated, removed, security, documentation, dependencies]
   default: patch
+autolabeler:
+  - label: breaking
+    title:
+      - '/^[a-z]+(\(.+\))?!:/'
+      - '/BREAKING[ -]CHANGE/'
+  - label: enhancement
+    title: ['/^feat(\(.+\))?:/']
+  - label: fix
+    title: ['/^fix(\(.+\))?:/']
+  - label: performance
+    title: ['/^perf(\(.+\))?:/']
+  - label: refactor
+    title: ['/^refactor(\(.+\))?:/']
+  - label: documentation
+    title: ['/^docs(\(.+\))?:/']
+  - label: dependencies
+    title:
+      - '/^build(\(.+\))?:/'
+      - '/^chore\(deps.*\):/'
+  - label: security
+    title: ['/^security(\(.+\))?:/']
+  - label: skip-changelog
+    title:
+      - '/^(ci|test|style)(\(.+\))?:/'
+      - '/^chore(?!\(deps)(\(.+\))?:/'
 exclude-labels:
   - skip-changelog

--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -6,6 +6,7 @@ name: Release Manager
 # the maintainer publishes the Release manually, which creates the tag and
 # triggers the npm publish workflow.
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What
- Add `workflow_dispatch` to `job-version-bump.yaml` so the Release Manager can be run on demand (and recovered after a skipped run).
- Replace `release-drafter.yml` with the canonical config.

## Why
The Release Manager ran once (on #99) and resolved **`v3.3.1-beta.0`** instead of `v4.0.0`. Two causes, both in `release-drafter.yml`:
1. `version-resolver` keyed on `major`/`minor`/`patch` labels that don't exist here, so every PR fell through to `default: patch`. The canonical config keys on `breaking` -> major, `enhancement` -> minor, the rest -> patch. With #88 labeled `breaking`, it now resolves **major -> 4.0.0**.
2. `prerelease-identifier: beta` forced a prerelease suffix. Removed -- stable-only.

Also adds the autolabeler (derives the label from the conventional-commit PR title).

## Verification
- YAML parses for both files.
- A dispatch / next push to main resolves `4.0.0` (breaking present, no prerelease).

Closes #102

> Note: the Release Manager's commit push to `main` still needs the release App added as a branch-ruleset bypass actor, or the `[skip ci]` prep commit is rejected. That is a one-time repo setup step.