### PR TITLE
fix(ci): skip PR Body check for Dependabot

### DIFF
--- a/.github/workflows/job-pr-checks.yaml
+++ b/.github/workflows/job-pr-checks.yaml
@@ -56,6 +56,9 @@ jobs:
 
   pr-body:
     name: PR Body
+    # Dependabot PRs have no template body or issue reference; skip them so the
+    # body check does not block their auto-merge.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check body


### PR DESCRIPTION
## What
Sync the `pr-body` Dependabot guard from project-template into `job-pr-checks.yaml`.

## Why
Dependabot PRs have no template body or issue reference, so `pr-body` failed them and blocked `job-dependabot-auto-merge.yaml`. `pr-title` and `pr-hygiene` still run.

## Verification
- Only change vs the synced file is `if: github.actor != 'dependabot[bot]'` on `pr-body`.
- A skipped required job reports green to branch protection, unblocking auto-merge.

Closes #104