### PR TITLE
feat(api): verified message builder (createBuilder) + v4.0.0 docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ contract to respect:
 - **Explicit HL7 version.** The underlying libraries require an explicit HL7 version per client and
   per listener (no default). Thread it through the connection/listener options from the underlying
   library; never assume a fallback.
+- **Validated builds.** Prefer `app.hl7.createBuilder(version)` for a version-validated message
+  builder (chain `build*`, finish with `.toMessage()`); `buildMessage` is the lightweight,
+  unvalidated path.
 - **Acknowledge inbound messages** with `res.sendResponse("AA" | "AE" | "AR")`.
 - **Shutdown is automatic.** The plugin closes all clients and listeners on Fastify `preClose`; call
   `closeServer(port)` / `closeServerAll()` only to close early.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,36 @@ hook-enforced rules). Keep this file current when the build, layout, or public A
 
 ## What this is
 
-A Fastify v5 plugin (built on `fastify-plugin`) that wraps the
-[`node-hl7-client`](https://github.com/Bugs5382/node-hl7-client) and
-[`node-hl7-server`](https://github.com/Bugs5382/node-hl7-server) libraries so a Fastify app can
+A Fastify v5 plugin (built on `fastify-plugin`) that wraps the `node-hl7-client` and
+`node-hl7-server` packages — both shipped from the
+[`node-hl7`](https://github.com/Bugs5382/node-hl7) repo — so a Fastify app can
 send and receive HL7 v2.x messages over MLLP. The plugin decorates the Fastify instance with
 factories for HL7 clients, listeners, and message/batch builders; it does not re-document the
 underlying libraries (see their repos for transport and builder details).
 
 Published to npm as `fastify-hl7`. Ships dual ESM + CJS with type declarations.
+
+## Using fastify-hl7 in an app
+
+If you are an agent wiring this plugin into a Fastify app (not editing this repo), start from the
+[README](./README.md) — it has the full `fastify.hl7` API reference and runnable recipes (round-trip,
+routing, multiple clients, builders, ACK/NAK, parsing, shutdown, TLS, lookups, error handling). The
+contract to respect:
+
+- **Single entry point.** Register the plugin (`await app.register(fastifyHL7, opts)`) and use the
+  `app.hl7` decorator for everything. Do not import `node-hl7-client` / `node-hl7-server` directly in
+  app code.
+- **Names.** A client name and an inbound-listener name must be unique and free of spaces and the
+  special characters listed in the README. An outbound `createConnection(name, ...)` references an
+  existing **client** name.
+- **Explicit HL7 version.** The underlying libraries require an explicit HL7 version per client and
+  per listener (no default). Thread it through the connection/listener options from the underlying
+  library; never assume a fallback.
+- **Acknowledge inbound messages** with `res.sendResponse("AA" | "AE" | "AR")`.
+- **Shutdown is automatic.** The plugin closes all clients and listeners on Fastify `preClose`; call
+  `closeServer(port)` / `closeServerAll()` only to close early.
+- **`enableServer: false`** turns off the server; server-side methods then throw
+  `FASTIFY_HL7_ERR_USAGE`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,34 @@ Reusing the same port on the same client throws — pick a distinct outbound por
 
 ### 4. Build messages, batches, and file batches
 
+For a **validated** message, use `createBuilder(version)`. It returns node-hl7-client's
+version-pinned builder, which validates every field against that HL7 version (withdrawn fields throw,
+backward-compatibility fields warn, segments not in the version are rejected) and sets `MSH.12` to
+the version for you. Chain `build*` calls and finish with `toMessage()`:
+
 ```ts
-// A single message — MSH.12 must match the sending client's version.
-const message = app.hl7.buildMessage({
+const message = app.hl7
+  .createBuilder("2.7")
+  .buildMSH({
+    msh_3: "MY_APP",
+    msh_4: "MY_FAC",
+    msh_5: "EPIC",
+    msh_6: "HOSP",
+    msh_9_1: "ADT",
+    msh_9_2: "A01",
+    msh_10: "MSG00001",
+    msh_11_1: "P",
+  })
+  .buildPID({ pid_3: "MRN12345", pid_5: "DOE^JANE^A", pid_8: "F" })
+  .toMessage();
+```
+
+Because the builder pins the version, its `MSH.12` always matches a client created with the same
+`version`. For a lightweight, **unvalidated** message, `buildMessage` constructs one directly (set
+`messageHeader.msh_12` yourself):
+
+```ts
+const quick = app.hl7.buildMessage({
   messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P", msh_12: "2.7" },
 });
 
@@ -235,10 +260,8 @@ const fileBatch = app.hl7.buildFileBatch();
 const stamp = app.hl7.buildDate(new Date(), 14);
 ```
 
-> Building takes the message/batch/builder options from `node-hl7-client`. `buildFileBatch` is for
-> *creating* a file batch — to read an existing one, use `readFile` / `readFileBuffer`
-> ([recipe 5](#5-parse-inbound-hl7-and-read-files)). For the richer class-based builder
-> (`new HL7_2_7().buildMSH(...).buildPID(...)`), see the node-hl7-client docs.
+> `buildFileBatch` is for *creating* a file batch — to read an existing one, use `readFile` /
+> `readFileBuffer` ([recipe 5](#5-parse-inbound-hl7-and-read-files)).
 
 ### 5. Parse inbound HL7 and read files
 
@@ -376,7 +399,8 @@ The server methods throw `FASTIFY_HL7_ERR_USAGE` when the plugin was registered 
 
 | Method | Returns | Description |
 |---|---|---|
-| `buildMessage(options?)` | `Message` | Build a single HL7 message (set `messageHeader.msh_12` to the client version). |
+| `createBuilder(version, options?)` | `HL7_2_x` | Version-pinned, **validated** builder; chain `build*` then `.toMessage()`. Rejects fields/segments not valid for the version. |
+| `buildMessage(options?)` | `Message` | Build a single HL7 message directly, **unvalidated** (set `messageHeader.msh_12` to the client version). |
 | `buildBatch(options?)` | `Batch` | Build an HL7 batch (BHS). |
 | `buildFileBatch(options?)` | `FileBatch` | Build an HL7 file batch (FHS) for writing. |
 | `buildDate(date, length?)` | `string` | Format a `Date` as an HL7 timestamp (length `8`, `12`, or `14`; default `14`). |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,15 @@ If you use this package, please consider giving it a ⭐ — it raises visibilit
 contribution from the outside.
 
 > This documentation covers **how to use the plugin**. It does not re-document the underlying
-> libraries (message building, segments, transport, the HL7 version a connection negotiates). For
-> those, see [External Libraries](#-external-libraries).
+> libraries (segment-by-segment message building, transport internals). For those, see
+> [External Libraries](#-external-libraries).
+
+> 🟢 **Requires Node.js ≥ 22** (inherited from the underlying `node-hl7` packages).
+
+> ⚠️ **HL7 version is required.** Every client and every inbound listener must pin an explicit
+> `version` — one of `"2.1" | "2.2" | "2.3" | "2.3.1" | "2.4" | "2.5" | "2.5.1" | "2.6" | "2.7" |
+> "2.7.1" | "2.8"`. There is no default. A client's `version` must match the `MSH.12` of every
+> message it sends; an inbound listener rejects (`AR`) any message whose `MSH.12` differs.
 
 ## Table of Contents
 
@@ -44,6 +51,8 @@ contribution from the outside.
 npm install fastify-hl7
 ```
 
+Requires Node.js ≥ 22.
+
 ## 🚀 Basic Usage
 
 ### Register the plugin
@@ -63,13 +72,13 @@ pass `{ enableServer: false }` for a client-only app (see [Plugin Options](#-plu
 
 ### Server quick start
 
-Create an inbound listener. The handler receives each inbound message and replies with an
-acknowledgement code (`"AA"` accept, `"AE"` error, `"AR"` reject):
+Create an inbound listener. It must pin an HL7 `version`. The handler receives each inbound message
+and replies with an acknowledgement code (`"AA"` accept, `"AE"` error, `"AR"` reject):
 
 ```ts
 const listener = app.hl7.createInbound(
   "ib_adt",
-  { port: 3001 },
+  { port: 3001, version: "2.7" },
   async (req, res) => {
     const message = req.getMessage();
     const type = req.getType();
@@ -80,17 +89,18 @@ const listener = app.hl7.createInbound(
 );
 ```
 
-`createInbound` returns the listener so you can attach advanced event handlers if needed.
+`createInbound` returns the listener so you can attach advanced event handlers if needed. Any inbound
+message whose `MSH.12` is not `"2.7"` is rejected with an `AR` before your handler runs.
 
 ### Client quick start
 
-A **client** is a named handle to one remote host. Outbound **connections** are attached to that
-client by its name — so the first argument to `createConnection` is the **client name**, not a new
-identifier:
+A **client** is a named handle to one remote host and pins the HL7 `version` for everything it
+sends. Outbound **connections** are attached to that client by its name — so the first argument to
+`createConnection` is the **client name**, not a new identifier (it inherits the client's version):
 
 ```ts
-// 1. Register a named client pointed at a remote host.
-app.hl7.createClient("adt_host", { host: "127.0.0.1" });
+// 1. Register a named client pointed at a remote host, pinned to an HL7 version.
+app.hl7.createClient("adt_host", { host: "127.0.0.1", version: "2.7" });
 
 // 2. Attach an outbound connection to that client (note: "adt_host" matches above).
 const connection = app.hl7.createConnection(
@@ -98,16 +108,18 @@ const connection = app.hl7.createConnection(
   { port: 3001 },
   async (res) => {
     const reply = res.getMessage();
-    // Handle the ACK/NAK the remote returned.
+    // Handle the ACK/NAK the remote returned, e.g. res.getMessage().get("MSA.1").
   },
 );
 
-// 3. Build a message and send it.
+// 3. Build a message (its MSH.12 must match the client version) and send it.
 const message = app.hl7.buildMessage({
   messageHeader: {
     msh_9_1: "ADT",
     msh_9_2: "A01",
-    msh_11_1: "D",
+    msh_10: "MSG00001",
+    msh_11_1: "P",
+    msh_12: "2.7",
   },
 });
 
@@ -125,7 +137,8 @@ The client name is a unique identifier for a host, so you can attach several out
 ### 1. Full round-trip in one app
 
 A single Fastify app that listens for inbound HL7 **and** sends outbound HL7 to itself — useful for
-local testing or a relay:
+local testing or a relay. Keep the versions aligned across the listener, the client, and the
+message:
 
 ```ts
 import fastify from "fastify";
@@ -135,36 +148,37 @@ const app = fastify();
 await app.register(fastifyHL7);
 
 // Inbound: accept everything, echo back an "AA".
-app.hl7.createInbound("ib_adt", { port: 3001 }, async (req, res) => {
+app.hl7.createInbound("ib_adt", { port: 3001, version: "2.7" }, async (req, res) => {
   app.log.info("inbound %s", req.getType());
   await res.sendResponse("AA");
 });
 
-// Outbound: a client pointed at our own listener.
-app.hl7.createClient("self", { host: "127.0.0.1" });
+// Outbound: a client pointed at our own listener, same version.
+app.hl7.createClient("self", { host: "127.0.0.1", version: "2.7" });
 const out = app.hl7.createConnection("self", { port: 3001 }, async (res) => {
-  app.log.info("ack: %o", res.getMessage());
+  app.log.info("ack: %s", res.getMessage().get("MSA.1").toString());
 });
 
 await app.listen({ port: 3000 });
 
 const message = app.hl7.buildMessage({
-  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "D" },
+  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P", msh_12: "2.7" },
 });
 await out.sendMessage(message);
 ```
 
 ### 2. Route multiple inbound listeners
 
-One server hosts many inbound listeners on different ports — for example, one per feed:
+One server hosts many inbound listeners on different ports — for example, one per feed. Each pins
+its own version:
 
 ```ts
-app.hl7.createInbound("adt_feed", { port: 3001 }, async (req, res) => {
+app.hl7.createInbound("adt_feed", { port: 3001, version: "2.7" }, async (req, res) => {
   // ADT (admit/discharge/transfer) feed.
   await res.sendResponse("AA");
 });
 
-app.hl7.createInbound("oru_feed", { port: 3002 }, async (req, res) => {
+app.hl7.createInbound("oru_feed", { port: 3002, version: "2.7" }, async (req, res) => {
   // ORU (observation result) feed; branch on the message type.
   if (req.getType() === "ORU") {
     // ...persist the result...
@@ -180,19 +194,21 @@ app.hl7.createInbound("oru_feed", { port: 3002 }, async (req, res) => {
 
 ### 3. Multiple clients and outbound connections
 
-An interface engine often talks to several downstream systems. Create one client per host, and one
-connection per port on that host:
+An interface engine often talks to several downstream systems. Create one client per host (each with
+its version), and one connection per port on that host:
 
 ```ts
-app.hl7.createClient("lab", { host: "10.0.0.10" });
-app.hl7.createClient("pharmacy", { host: "10.0.0.20" });
+app.hl7.createClient("lab", { host: "10.0.0.10", version: "2.5.1" });
+app.hl7.createClient("pharmacy", { host: "10.0.0.20", version: "2.7" });
 
 const labOrders = app.hl7.createConnection("lab", { port: 6661 }, async () => {});
 const labResults = app.hl7.createConnection("lab", { port: 6662 }, async () => {});
 const rxOrders = app.hl7.createConnection("pharmacy", { port: 6661 }, async () => {});
 
 await labOrders.sendMessage(
-  app.hl7.buildMessage({ messageHeader: { msh_9_1: "ORM", msh_9_2: "O01", msh_11_1: "P" } }),
+  app.hl7.buildMessage({
+    messageHeader: { msh_9_1: "ORM", msh_9_2: "O01", msh_11_1: "P", msh_12: "2.5.1" },
+  }),
 );
 ```
 
@@ -201,9 +217,9 @@ Reusing the same port on the same client throws — pick a distinct outbound por
 ### 4. Build messages, batches, and file batches
 
 ```ts
-// A single message.
+// A single message — MSH.12 must match the sending client's version.
 const message = app.hl7.buildMessage({
-  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P" },
+  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P", msh_12: "2.7" },
 });
 
 // A batch (BHS) that groups several messages.
@@ -221,7 +237,8 @@ const stamp = app.hl7.buildDate(new Date(), 14);
 
 > Building takes the message/batch/builder options from `node-hl7-client`. `buildFileBatch` is for
 > *creating* a file batch — to read an existing one, use `readFile` / `readFileBuffer`
-> ([recipe 5](#5-parse-inbound-hl7-and-read-files)).
+> ([recipe 5](#5-parse-inbound-hl7-and-read-files)). For the richer class-based builder
+> (`new HL7_2_7().buildMSH(...).buildPID(...)`), see the node-hl7-client docs.
 
 ### 5. Parse inbound HL7 and read files
 
@@ -242,7 +259,7 @@ const fromBuffer = app.hl7.readFileBuffer(readFileSync("temp/hl7.readTestBHS.202
 Inside an inbound handler, reply with the acknowledgement code that fits the outcome:
 
 ```ts
-app.hl7.createInbound("ib_adt", { port: 3001 }, async (req, res) => {
+app.hl7.createInbound("ib_adt", { port: 3001, version: "2.7" }, async (req, res) => {
   try {
     const message = req.getMessage();
     // ...process the message...
@@ -255,7 +272,8 @@ app.hl7.createInbound("ib_adt", { port: 3001 }, async (req, res) => {
 ```
 
 Use `"AR"` (Application Reject) for messages you will not process at all (wrong type, unsupported
-trigger, etc.).
+trigger, etc.). For verbatim, vendor-shaped acknowledgements, `node-hl7-server` exposes
+`sendCustomResponse`.
 
 ### 7. Graceful shutdown
 
@@ -280,9 +298,12 @@ Server options pass straight through to `node-hl7-server` and can only be set at
 (you cannot change them after the server is created):
 
 ```ts
+import { readFileSync } from "node:fs";
+
 await app.register(fastifyHL7, {
   serverOptions: {
-    // e.g. enable IPv6, bind options, or TLS — see node-hl7-server's ServerOptions.
+    // e.g. bindAddress, IPv6, or TLS — see node-hl7-server's ServerOptions.
+    bindAddress: "0.0.0.0",
     tls: {
       key: readFileSync("server.key"),
       cert: readFileSync("server.crt"),
@@ -290,6 +311,9 @@ await app.register(fastifyHL7, {
   },
 });
 ```
+
+Client-side TLS is set per client via the `tls` option on `createClient`
+(`{ host, version, tls: true | ConnectionOptions }`).
 
 ### 9. Look up live clients and listeners
 
@@ -312,7 +336,7 @@ Guard accordingly:
 await app.register(fastifyHL7, { enableServer: false });
 
 try {
-  app.hl7.createInbound("ib", { port: 3001 }, async () => {});
+  app.hl7.createInbound("ib", { port: 3001, version: "2.7" }, async () => {});
 } catch (err) {
   // FASTIFY_HL7_ERR_USAGE: "server was not started.
   // re-register plugin with enableServer set to true."
@@ -330,7 +354,7 @@ All methods hang off the `hl7` decorator on the Fastify instance.
 
 | Method | Returns | Description |
 |---|---|---|
-| `createInbound(name, options, handler)` | `Inbound` | Start an inbound listener on `options.port`; `handler(req, res)` handles each message. |
+| `createInbound(name, options, handler)` | `Inbound` | Start an inbound listener on `options.port` pinned to `options.version`; `handler(req, res)` handles each message. |
 | `closeServer(port)` | `Promise<boolean>` | Close the listener on `port`. |
 | `closeServerAll()` | `Promise<boolean>` | Close all listeners. |
 | `getServerByName(name)` | `Inbound \| undefined` | Look up a listener by name. |
@@ -343,7 +367,7 @@ The server methods throw `FASTIFY_HL7_ERR_USAGE` when the plugin was registered 
 
 | Method | Returns | Description |
 |---|---|---|
-| `createClient(name, options)` | `Client` | Register a uniquely named client pointed at `options.host`. |
+| `createClient(name, options)` | `Client` | Register a uniquely named client pointed at `options.host` and pinned to `options.version`. |
 | `createConnection(name, options, handler)` | `Connection` | Attach an outbound connection (on `options.port`) to the client called `name`; `handler(res)` handles the reply. |
 | `getClientByName(name)` | `Client \| undefined` | Look up a client by name. |
 | `getClientConnectionByPort(port)` | `Connection \| undefined` | Look up an outbound connection by port. |
@@ -352,7 +376,7 @@ The server methods throw `FASTIFY_HL7_ERR_USAGE` when the plugin was registered 
 
 | Method | Returns | Description |
 |---|---|---|
-| `buildMessage(options?)` | `Message` | Build a single HL7 message. |
+| `buildMessage(options?)` | `Message` | Build a single HL7 message (set `messageHeader.msh_12` to the client version). |
 | `buildBatch(options?)` | `Batch` | Build an HL7 batch (BHS). |
 | `buildFileBatch(options?)` | `FileBatch` | Build an HL7 file batch (FHS) for writing. |
 | `buildDate(date, length?)` | `string` | Format a `Date` as an HL7 timestamp (length `8`, `12`, or `14`; default `14`). |
@@ -377,15 +401,17 @@ While disabled, the server-side methods throw `FASTIFY_HL7_ERR_USAGE`.
 ### `serverOptions`
 
 The `ServerOptions` from
-[`node-hl7-server`](https://github.com/Bugs5382/node-hl7-server/blob/main/README.md). Use it to
-enable IPv4/IPv6, TLS, and other server-creation settings. It can only be set at registration time.
+[`node-hl7-server`](https://github.com/Bugs5382/node-hl7) — `bindAddress`, encoding, TLS, and other
+server-creation settings. It can only be set at registration time.
+
+> Per-client and per-listener settings (including the required HL7 `version`, host, port, and TLS)
+> are passed to `createClient` / `createConnection` / `createInbound`, not here.
 
 ## 🔌 External Libraries
 
-This plugin documents only its own surface. For message content, segment building, transport, and
-the **HL7 version** a client/listener negotiates (the underlying libraries require an explicit
-version — there is no default), see the [`node-hl7`](https://github.com/Bugs5382/node-hl7) repo,
-which ships both packages:
+This plugin documents only its own surface. For segment-by-segment message building (the class-based
+`HL7_2_x` builders), transport internals, parsing, and the full client/server option sets, see the
+[`node-hl7`](https://github.com/Bugs5382/node-hl7) repo, which ships both packages:
 
 - `node-hl7-client` — Client, Parser, and Builder options.
 - `node-hl7-server` — Server and Inbound options.

--- a/README.md
+++ b/README.md
@@ -1,86 +1,108 @@
-# Fastify HL7
+# 🏥 Fastify HL7
 
-A Fastify Hl7 Plugin Developed in Pure TypeScript.
-It uses the [node-hl7-client](https://github.com/Bugs5382/node-hl7-client) and [node-hl7-server](https://github.com/Bugs5382/node-hl7-server) plugin as a wrapper.
+A Fastify HL7 plugin developed in pure TypeScript.
+It wraps the `node-hl7-client` and `node-hl7-server` packages — both shipped from the
+[`node-hl7`](https://github.com/Bugs5382/node-hl7) repo — so a Fastify app can send and
+receive HL7 v2.x messages over MLLP.
 
-The build exports this to valid ESM and CJS for ease of cross-compatibility.
+The build exports valid ESM and CJS for cross-compatibility.
 
-If you are using this NPM package, please consider giving it a :star: star.
-This will increase its visibility and solicit more contribution from the outside.
+If you use this package, please consider giving it a ⭐ — it raises visibility and brings in more
+contribution from the outside.
 
-This documentation is how to use this plugin, not on how to use the libraries above.
-Head [here](#external-libraries-options) if you need help with those.
+> This documentation covers **how to use the plugin**. It does not re-document the underlying
+> libraries (message building, segments, transport, the HL7 version a connection negotiates). For
+> those, see [External Libraries](#-external-libraries).
 
 ## Table of Contents
 
-1. [Install](#install)
-2. [Basic Usage](#basic-usage)
-   1. [Server Quick Start](#server-quick-start)
-   2. [Client Quick Start](#client-quick-start)
-3. [Full Documentation](#full-documentation)
-   1. [This Library Options](#this-library-options)
-   2. [External Libraries Options](#external-libraries-options)
-4. [Acknowledgements](#acknowledgements)
-5. [License](#license)
+1. [Install](#-install)
+2. [Basic Usage](#-basic-usage)
+   1. [Register the plugin](#register-the-plugin)
+   2. [Server quick start](#server-quick-start)
+   3. [Client quick start](#client-quick-start)
+3. [Recipes](#-recipes)
+   1. [Full round-trip in one app](#1-full-round-trip-in-one-app)
+   2. [Route multiple inbound listeners](#2-route-multiple-inbound-listeners)
+   3. [Multiple clients and outbound connections](#3-multiple-clients-and-outbound-connections)
+   4. [Build messages, batches, and file batches](#4-build-messages-batches-and-file-batches)
+   5. [Parse inbound HL7 and read files](#5-parse-inbound-hl7-and-read-files)
+   6. [ACK / NAK responses](#6-ack--nak-responses)
+   7. [Graceful shutdown](#7-graceful-shutdown)
+   8. [TLS and server options](#8-tls-and-server-options)
+   9. [Look up live clients and listeners](#9-look-up-live-clients-and-listeners)
+   10. [Error handling when the server is disabled](#10-error-handling-when-the-server-is-disabled)
+4. [API Reference](#-api-reference-fastifyhl7)
+5. [Plugin Options](#-plugin-options)
+6. [External Libraries](#-external-libraries)
+7. [Acknowledgements](#-acknowledgements)
+8. [License](#-license)
 
-## Install
+## 📦 Install
 
-```
+```shell
 npm install fastify-hl7
 ```
 
-## Basic Usage
+## 🚀 Basic Usage
 
-Register this as a plugin.
+### Register the plugin
 
 ```ts
-await fastify.register(fastifyHL7);
+import fastify from "fastify";
+import fastifyHL7 from "fastify-hl7";
+
+const app = fastify();
+
+await app.register(fastifyHL7);
 ```
 
-### Server Quick Start
+Registering decorates the Fastify instance with `app.hl7` — the single entry point for HL7
+clients, inbound listeners, and message builders. By default the inbound **server** is enabled;
+pass `{ enableServer: false }` for a client-only app (see [Plugin Options](#-plugin-options)).
+
+### Server quick start
+
+Create an inbound listener. The handler receives each inbound message and replies with an
+acknowledgement code (`"AA"` accept, `"AE"` error, `"AR"` reject):
 
 ```ts
-const listener = fastify.hl7.createInbound(
+const listener = app.hl7.createInbound(
   "ib_adt",
   { port: 3001 },
   async (req, res) => {
-    const messageReq = req.getMessage();
-    const messageType = req.getType();
-    // your logic here
+    const message = req.getMessage();
+    const type = req.getType();
+    app.log.info("received %s", type);
+    // ...your logic here...
     await res.sendResponse("AA");
   },
 );
 ```
 
-This will create a inbound connection. You can optionally return it to a variable to attach advanced listeners.
+`createInbound` returns the listener so you can attach advanced event handlers if needed.
 
-### Client Quick Start
+### Client quick start
 
-```ts
-import fastify from "fastify";
-
-fastify.hl7.createClient("localhost", { host: "0.0.0.0" });
-```
-
-This will create a "client" class that will then allow you to attach different outbound connections.
-The name `localhost` in a unique identifier to this host, so it can be used to attach different outbound connections to this server/broker.
-
-There might be times when your HL7 messages need to cross-over to different hosts/server/inbound endpoints and this is how you would get them.
-
-Within your code now you can use the fastify context and access the `hl7` decorator,
-and create an outbound connection.
+A **client** is a named handle to one remote host. Outbound **connections** are attached to that
+client by its name — so the first argument to `createConnection` is the **client name**, not a new
+identifier:
 
 ```ts
-const client = fastify.hl7.createConnection(
-  "ob_adt",
+// 1. Register a named client pointed at a remote host.
+app.hl7.createClient("adt_host", { host: "127.0.0.1" });
+
+// 2. Attach an outbound connection to that client (note: "adt_host" matches above).
+const connection = app.hl7.createConnection(
+  "adt_host",
   { port: 3001 },
   async (res) => {
-    const messageRes = res.getMessage();
-    // Your code here. Either a failure or a success, but still do your work here.
+    const reply = res.getMessage();
+    // Handle the ACK/NAK the remote returned.
   },
 );
 
-// building a HL7 Message Segment
+// 3. Build a message and send it.
 const message = app.hl7.buildMessage({
   messageHeader: {
     msh_9_1: "ADT",
@@ -89,33 +111,289 @@ const message = app.hl7.buildMessage({
   },
 });
 
-await client.sendMessage(message);
+await connection.sendMessage(message);
 ```
 
-## Full Documentation
+The client name is a unique identifier for a host, so you can attach several outbound connections
+(different ports) to the same host, and create several clients for different hosts.
 
-### This Library Options
+> ⚠️ A client name must be unique and may not contain spaces or the characters
+> `` `!@#$%^&*()+-=[]{};':"\|,.<>/?~ ``. The same rule applies to inbound listener names.
+
+## 🧩 Recipes
+
+### 1. Full round-trip in one app
+
+A single Fastify app that listens for inbound HL7 **and** sends outbound HL7 to itself — useful for
+local testing or a relay:
+
+```ts
+import fastify from "fastify";
+import fastifyHL7 from "fastify-hl7";
+
+const app = fastify();
+await app.register(fastifyHL7);
+
+// Inbound: accept everything, echo back an "AA".
+app.hl7.createInbound("ib_adt", { port: 3001 }, async (req, res) => {
+  app.log.info("inbound %s", req.getType());
+  await res.sendResponse("AA");
+});
+
+// Outbound: a client pointed at our own listener.
+app.hl7.createClient("self", { host: "127.0.0.1" });
+const out = app.hl7.createConnection("self", { port: 3001 }, async (res) => {
+  app.log.info("ack: %o", res.getMessage());
+});
+
+await app.listen({ port: 3000 });
+
+const message = app.hl7.buildMessage({
+  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "D" },
+});
+await out.sendMessage(message);
+```
+
+### 2. Route multiple inbound listeners
+
+One server hosts many inbound listeners on different ports — for example, one per feed:
+
+```ts
+app.hl7.createInbound("adt_feed", { port: 3001 }, async (req, res) => {
+  // ADT (admit/discharge/transfer) feed.
+  await res.sendResponse("AA");
+});
+
+app.hl7.createInbound("oru_feed", { port: 3002 }, async (req, res) => {
+  // ORU (observation result) feed; branch on the message type.
+  if (req.getType() === "ORU") {
+    // ...persist the result...
+    await res.sendResponse("AA");
+  } else {
+    await res.sendResponse("AR"); // reject anything unexpected on this port
+  }
+});
+```
+
+> There is only **one** server per host (the machine this runs on), but it can host any number of
+> inbound listeners on distinct ports.
+
+### 3. Multiple clients and outbound connections
+
+An interface engine often talks to several downstream systems. Create one client per host, and one
+connection per port on that host:
+
+```ts
+app.hl7.createClient("lab", { host: "10.0.0.10" });
+app.hl7.createClient("pharmacy", { host: "10.0.0.20" });
+
+const labOrders = app.hl7.createConnection("lab", { port: 6661 }, async () => {});
+const labResults = app.hl7.createConnection("lab", { port: 6662 }, async () => {});
+const rxOrders = app.hl7.createConnection("pharmacy", { port: 6661 }, async () => {});
+
+await labOrders.sendMessage(
+  app.hl7.buildMessage({ messageHeader: { msh_9_1: "ORM", msh_9_2: "O01", msh_11_1: "P" } }),
+);
+```
+
+Reusing the same port on the same client throws — pick a distinct outbound port per connection.
+
+### 4. Build messages, batches, and file batches
+
+```ts
+// A single message.
+const message = app.hl7.buildMessage({
+  messageHeader: { msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P" },
+});
+
+// A batch (BHS) that groups several messages.
+const batch = app.hl7.buildBatch();
+batch.start();
+batch.add(message);
+batch.end();
+
+// A file batch (FHS) for writing HL7 to disk.
+const fileBatch = app.hl7.buildFileBatch();
+
+// An HL7-formatted timestamp (length 8, 12, or 14 — 14 is the default).
+const stamp = app.hl7.buildDate(new Date(), 14);
+```
+
+> Building takes the message/batch/builder options from `node-hl7-client`. `buildFileBatch` is for
+> *creating* a file batch — to read an existing one, use `readFile` / `readFileBuffer`
+> ([recipe 5](#5-parse-inbound-hl7-and-read-files)).
+
+### 5. Parse inbound HL7 and read files
+
+```ts
+// Parse a raw string — returns a Batch if it starts with BHS, otherwise a Message.
+const parsed = app.hl7.processHL7(rawHl7String);
+
+// Read a file batch from disk.
+const fromPath = app.hl7.readFile("temp/hl7.readTestBHS.20231208.hl7");
+
+// Or from a Buffer you already have in memory.
+import { readFileSync } from "node:fs";
+const fromBuffer = app.hl7.readFileBuffer(readFileSync("temp/hl7.readTestBHS.20231208.hl7"));
+```
+
+### 6. ACK / NAK responses
+
+Inside an inbound handler, reply with the acknowledgement code that fits the outcome:
+
+```ts
+app.hl7.createInbound("ib_adt", { port: 3001 }, async (req, res) => {
+  try {
+    const message = req.getMessage();
+    // ...process the message...
+    await res.sendResponse("AA"); // Application Accept
+  } catch (err) {
+    req.log?.error(err);
+    await res.sendResponse("AE"); // Application Error
+  }
+});
+```
+
+Use `"AR"` (Application Reject) for messages you will not process at all (wrong type, unsupported
+trigger, etc.).
+
+### 7. Graceful shutdown
+
+You do **not** need to close clients or listeners by hand. The plugin registers Fastify `preClose`
+hooks that close every outbound connection and inbound listener when the app shuts down:
+
+```ts
+const app = fastify();
+await app.register(fastifyHL7);
+// ...create clients and listeners...
+
+// On app.close() / SIGINT, all HL7 connections close automatically.
+await app.close();
+```
+
+To close a single listener early, use `app.hl7.closeServer(port)`; to close them all,
+`app.hl7.closeServerAll()`.
+
+### 8. TLS and server options
+
+Server options pass straight through to `node-hl7-server` and can only be set at registration time
+(you cannot change them after the server is created):
+
+```ts
+await app.register(fastifyHL7, {
+  serverOptions: {
+    // e.g. enable IPv6, bind options, or TLS — see node-hl7-server's ServerOptions.
+    tls: {
+      key: readFileSync("server.key"),
+      cert: readFileSync("server.crt"),
+    },
+  },
+});
+```
+
+### 9. Look up live clients and listeners
+
+Retrieve handles you created earlier, by name or by port:
+
+```ts
+const labClient = app.hl7.getClientByName("lab");           // Client | undefined
+const conn = app.hl7.getClientConnectionByPort("6661");     // Connection | undefined
+
+const adtListener = app.hl7.getServerByName("adt_feed");    // Inbound | undefined
+const onPort = app.hl7.getServerByPort("3001");             // Inbound | undefined
+```
+
+### 10. Error handling when the server is disabled
+
+If you register with `{ enableServer: false }`, every server-side method throws a usage error.
+Guard accordingly:
+
+```ts
+await app.register(fastifyHL7, { enableServer: false });
+
+try {
+  app.hl7.createInbound("ib", { port: 3001 }, async () => {});
+} catch (err) {
+  // FASTIFY_HL7_ERR_USAGE: "server was not started.
+  // re-register plugin with enableServer set to true."
+  app.log.error(err);
+}
+```
+
+Registering the plugin twice also throws (`FASTIFY_HL7_ERR_SETUP_ERRORS: "Already registered."`).
+
+## 📖 API Reference (`fastify.hl7`)
+
+All methods hang off the `hl7` decorator on the Fastify instance.
+
+### Inbound / server
+
+| Method | Returns | Description |
+|---|---|---|
+| `createInbound(name, options, handler)` | `Inbound` | Start an inbound listener on `options.port`; `handler(req, res)` handles each message. |
+| `closeServer(port)` | `Promise<boolean>` | Close the listener on `port`. |
+| `closeServerAll()` | `Promise<boolean>` | Close all listeners. |
+| `getServerByName(name)` | `Inbound \| undefined` | Look up a listener by name. |
+| `getServerByPort(port)` | `Inbound \| undefined` | Look up a listener by port. |
+
+The server methods throw `FASTIFY_HL7_ERR_USAGE` when the plugin was registered with
+`enableServer: false`.
+
+### Outbound / client
+
+| Method | Returns | Description |
+|---|---|---|
+| `createClient(name, options)` | `Client` | Register a uniquely named client pointed at `options.host`. |
+| `createConnection(name, options, handler)` | `Connection` | Attach an outbound connection (on `options.port`) to the client called `name`; `handler(res)` handles the reply. |
+| `getClientByName(name)` | `Client \| undefined` | Look up a client by name. |
+| `getClientConnectionByPort(port)` | `Connection \| undefined` | Look up an outbound connection by port. |
+
+### Builders
+
+| Method | Returns | Description |
+|---|---|---|
+| `buildMessage(options?)` | `Message` | Build a single HL7 message. |
+| `buildBatch(options?)` | `Batch` | Build an HL7 batch (BHS). |
+| `buildFileBatch(options?)` | `FileBatch` | Build an HL7 file batch (FHS) for writing. |
+| `buildDate(date, length?)` | `string` | Format a `Date` as an HL7 timestamp (length `8`, `12`, or `14`; default `14`). |
+
+### Parsing & files
+
+| Method | Returns | Description |
+|---|---|---|
+| `processHL7(text)` | `Batch \| Message` | Parse raw HL7 — `Batch` if it starts with BHS, else `Message`. |
+| `readFile(fullFilePath)` | `FileBatch` | Read a file batch from a path. |
+| `readFileBuffer(buffer)` | `FileBatch` | Read a file batch from a `Buffer`. |
+
+## ⚙️ Plugin Options
+
+Pass these to `app.register(fastifyHL7, options)`:
 
 ### `enableServer`
 
-If this is not set, enableServer will be set to `true`. You need to set this to `false` will turn off the server capabilities.
+`boolean` — defaults to `true`. Set to `false` to turn off the inbound server (client-only app).
+While disabled, the server-side methods throw `FASTIFY_HL7_ERR_USAGE`.
 
 ### `serverOptions`
 
-Set this using the options from the [node-hl7-serer](https://github.com/Bugs5382/node-hl7-server/blob/main/README.md) library ServerOptions values to override server creation.
-This could be enabling IPv4 or IPv6 and other server options including TLS. Since you cannot set this after run time, it has to be set during registration.
+The `ServerOptions` from
+[`node-hl7-server`](https://github.com/Bugs5382/node-hl7-server/blob/main/README.md). Use it to
+enable IPv4/IPv6, TLS, and other server-creation settings. It can only be set at registration time.
 
-### External Libraries Options
+## 🔌 External Libraries
 
-- [node-hl7-client](https://github.com/Bugs5382/node-hl7-client/blob/main/README.md) - For the Client, Parser, and Builder to review their options that can be passed as props.
-- [node-hl7-server](https://github.com/Bugs5382/node-hl7-server/blob/main/README.md) - For the Server to the options that can be passed as props.
+This plugin documents only its own surface. For message content, segment building, transport, and
+the **HL7 version** a client/listener negotiates (the underlying libraries require an explicit
+version — there is no default), see the [`node-hl7`](https://github.com/Bugs5382/node-hl7) repo,
+which ships both packages:
 
-Please review the libraries for more complete documentation.
+- `node-hl7-client` — Client, Parser, and Builder options.
+- `node-hl7-server` — Server and Inbound options.
 
-## Acknowledgements
+## 🙏 Acknowledgements
 
 - My Wife and Baby Girl.
 
-## License
+## 📄 License
 
 Licensed under [MIT](./LICENSE).

--- a/__tests__/hl7.test.ts
+++ b/__tests__/hl7.test.ts
@@ -343,5 +343,51 @@ describe("plugin fastify-hl7 tests", () => {
         }
       });
     });
+
+    describe("...createBuilder (verified build)", () => {
+      beforeEach(async () => {
+        await app.register(fastifyHL7, { enableServer: false });
+      });
+
+      test("...is exposed on the decorator", async () => {
+        expect(app.hl7).toHaveProperty("createBuilder");
+      });
+
+      test("...builds a version-pinned message", async () => {
+        const message = app.hl7
+          .createBuilder("2.7")
+          .buildMSH({
+            msh_10: "MSG00001",
+            msh_11_1: "P",
+            msh_3: "MY_APP",
+            msh_4: "MY_FAC",
+            msh_5: "EPIC",
+            msh_6: "HOSP",
+            msh_9_1: "ADT",
+            msh_9_2: "A01",
+          })
+          .toMessage();
+        const raw = message.toString();
+        expect(raw).toContain("ADT");
+        expect(raw).toContain("2.7");
+      });
+
+      test("...pins the requested version into MSH.12", async () => {
+        const message = app.hl7
+          .createBuilder("2.5")
+          .buildMSH({
+            msh_10: "MSG00001",
+            msh_11_1: "P",
+            msh_3: "MY_APP",
+            msh_4: "MY_FAC",
+            msh_5: "EPIC",
+            msh_6: "HOSP",
+            msh_9_1: "ADT",
+            msh_9_2: "A01",
+          })
+          .toMessage();
+        expect(message.toString()).toContain("2.5");
+      });
+    });
   });
 });

--- a/src/class/hL7Client.ts
+++ b/src/class/hL7Client.ts
@@ -30,6 +30,18 @@ import Client, {
   Connection,
   createHL7Date,
   FileBatch,
+  HL7_2_1,
+  HL7_2_2,
+  HL7_2_3,
+  HL7_2_3_1,
+  HL7_2_4,
+  HL7_2_5,
+  HL7_2_5_1,
+  HL7_2_6,
+  HL7_2_7,
+  HL7_2_7_1,
+  HL7_2_8,
+  HL7Version,
   isBatch,
   Message,
   OutboundHandler,
@@ -41,6 +53,37 @@ import { errors } from "../errors.js";
 /** Accepted HL7 date-length values, derived from node-hl7-client's
  * `createHL7Date` so it stays in sync with the upstream type. */
 export type DateLength = Parameters<typeof createHL7Date>[1];
+
+/** Maps an `HL7Version` string to the matching node-hl7-client builder class,
+ * so `createBuilder("2.7")` returns a fully typed `HL7_2_7`. */
+export interface HL7VersionBuilders {
+  "2.1": HL7_2_1;
+  "2.2": HL7_2_2;
+  "2.3": HL7_2_3;
+  "2.3.1": HL7_2_3_1;
+  "2.4": HL7_2_4;
+  "2.5": HL7_2_5;
+  "2.5.1": HL7_2_5_1;
+  "2.6": HL7_2_6;
+  "2.7": HL7_2_7;
+  "2.7.1": HL7_2_7_1;
+  "2.8": HL7_2_8;
+}
+
+/** Runtime version -> builder-class lookup backing `createBuilder`. */
+const HL7_BUILDERS = {
+  "2.1": HL7_2_1,
+  "2.2": HL7_2_2,
+  "2.3": HL7_2_3,
+  "2.3.1": HL7_2_3_1,
+  "2.4": HL7_2_4,
+  "2.5": HL7_2_5,
+  "2.5.1": HL7_2_5_1,
+  "2.6": HL7_2_6,
+  "2.7": HL7_2_7,
+  "2.7.1": HL7_2_7_1,
+  "2.8": HL7_2_8,
+} as const;
 
 export class HL7Client {
   /** @internal */
@@ -116,6 +159,33 @@ export class HL7Client {
       });
     }
     return true;
+  }
+
+  /**
+   * Create a version-pinned HL7 message builder
+   * @remarks Returns the node-hl7-client builder for the given HL7 version, with
+   * per-version field validation (withdrawn fields throw, backward-compatibility
+   * fields warn, segments not in that version are rejected). Chain `build*`
+   * methods and finish with `toMessage()`.
+   * @since 4.0.0
+   * @param version One of the supported HL7 versions ("2.1" - "2.8").
+   * @param properties Optional builder options (date format, separators, hardError).
+   * @example
+   * ```ts
+   * const message = fastify.hl7.createBuilder("2.7")
+   *   .buildMSH({ msh_9_1: "ADT", msh_9_2: "A01", msh_11_1: "P" })
+   *   .buildPID({ pid_3: "MRN12345", pid_5: "DOE^JANE^A" })
+   *   .toMessage();
+   * ```
+   */
+  createBuilder<V extends HL7Version>(
+    version: V,
+    properties?: ClientBuilderOptions,
+  ): HL7VersionBuilders[V] {
+    const Builder = HL7_BUILDERS[version] as new (
+      properties?: ClientBuilderOptions,
+    ) => HL7VersionBuilders[V];
+    return new Builder(properties);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import Client, {
   ClientBuilderOptions,
   Connection,
   FileBatch,
+  HL7Version,
   Message,
 } from "node-hl7-client";
 import Server, {
@@ -39,7 +40,11 @@ import Server, {
 
 import type { FastifyHL7Options } from "./decorate.js";
 
-import { type DateLength, HL7Client } from "./class/hL7Client.js";
+import {
+  type DateLength,
+  HL7Client,
+  type HL7VersionBuilders,
+} from "./class/hL7Client.js";
 import { HL7Server } from "./class/hL7Server.js";
 import { errors } from "./errors.js";
 import { validateOpts as validateOptions } from "./validation.js";
@@ -142,6 +147,12 @@ const fastifyHL7 = fp<FastifyHL7Options>(async (fastify, options) => {
       throw new errors.FASTIFY_HL7_ERR_USAGE(
         "server was not started. re-register plugin with enableServer set to true.",
       );
+    },
+    createBuilder: function <V extends HL7Version>(
+      version: V,
+      properties?: ClientBuilderOptions,
+    ): HL7VersionBuilders[V] {
+      return client.createBuilder(version, properties);
     },
     createClient: function (name, properties): Client {
       return client.createClient(name, properties);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ import Client, {
   ClientOptions,
   Connection,
   FileBatch,
+  HL7Version,
   Message,
   OutboundHandler,
 } from "node-hl7-client";
@@ -38,7 +39,7 @@ import Server, {
   ListenerOptions,
 } from "node-hl7-server";
 
-import { DateLength } from "./class/hL7Client.js";
+import { DateLength, HL7VersionBuilders } from "./class/hL7Client.js";
 
 declare module "fastify" {
   export interface FastifyInstance {
@@ -74,6 +75,14 @@ declare module "fastify" {
     /** Close all incoming HL7 ports.
      * @since 1.0.0 */
     closeServerAll: () => Promise<boolean>;
+    /** Create a version-pinned HL7 message builder.
+     * @remarks Returns the node-hl7-client builder for the given version with
+     * per-version field validation. Chain `build*` and finish with `toMessage()`.
+     * @since 4.0.0 */
+    createBuilder: <V extends HL7Version>(
+      version: V,
+      properties?: ClientBuilderOptions,
+    ) => HL7VersionBuilders[V];
     /** Create Client
      * @remarks Connecting to a remote server/broker that accepts connections.
      * @since 1.0.0 */


### PR DESCRIPTION
## What
Surface node-hl7 v4's headline capability through the plugin, and document the whole API.

- **`fastify.hl7.createBuilder(version)`** — returns the version-pinned node-hl7-client builder (`HL7_2_1`…`HL7_2_8`) with per-version field validation (withdrawn fields throw, segments not in the version are rejected). Chain `build*`, finish with `.toMessage()`. Typed via an `HL7Version` → builder-class map, so `createBuilder("2.7")` returns a fully typed `HL7_2_7`.
- **README** — ten runnable recipes, full `fastify.hl7` API reference, plugin options, the required-`version` rules, and Node ≥ 22. Fixes the broken Client Quick Start (`createConnection`'s first arg must match a registered client) and threads the required HL7 `version` through every example.
- **AGENTS.md** — a "using fastify-hl7 in an app" section.

## Why
#88 bumped the dependency to node-hl7 v4 but the decorator still only exposed the unvalidated `new Message()` path via `buildMessage` — the v4 verified builder was unreachable without importing node-hl7-client directly (which AGENTS.md forbids). This closes that gap for v4.0.0.

## Verification
- `npm run build` (tsdown + `tsc`), `npm run lint`, and `npm test` (42 tests, incl. 3 new `createBuilder` tests) all pass.
- `createBuilder("2.7")`/`("2.5")` pin `MSH.12` to the requested version.

Closes #106