### PR TITLE
fix(ci): grant action-deploy contents:write for the docs job

### DIFF
--- a/.github/workflows/action-deploy.yaml
+++ b/.github/workflows/action-deploy.yaml
@@ -10,7 +10,7 @@ on:
       - released
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## What
Set `action-deploy.yaml` top-level `permissions: contents: write` (keep `id-token: write`).

## Why
The `Document` job calls `action-docs.yaml` (`contents: write` to push gh-pages). With `contents: read` the reusable-workflow call exceeded the caller's grant, so the workflow failed validation and **no** job ran — including the npm publish.

## Verification
- YAML validates; the called docs workflow's `contents: write` is now within the caller's grant; OIDC publish unaffected.

Closes #111