### PR TITLE
fix(ci): generate a lockfile before the docs install

### DIFF
--- a/.github/workflows/action-docs.yaml
+++ b/.github/workflows/action-docs.yaml
@@ -37,6 +37,11 @@ jobs:
             echo "No gh-pages branch yet -- first publish."
           fi
 
+      # Generate the lockfile BEFORE setup-node so its npm cache has something to
+      # key on and `npm ci` has a lockfile (the repo does not commit one).
+      - name: Generate lockfile
+        run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## What
Add a `npm install --package-lock-only` step before setup-node in `action-docs.yaml`, mirroring `action-test.yaml`.

## Why
The docs job used `cache: 'npm'` + `npm ci` with no committed lockfile, failing with "Dependencies lock file is not found." npm 4.0.0 publishing already succeeded; this only affected the gh-pages docs job.

## Verification
- YAML validates; the docs job will generate the lockfile, install, run typedoc, and deploy.

Closes #114