### PR TITLE
fix(ci): pin typedoc-pages-action to v0.1.0

### DIFF
--- a/.github/workflows/action-docs.yaml
+++ b/.github/workflows/action-docs.yaml
@@ -26,6 +26,6 @@ jobs:
         run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
 
       - name: Publish versioned docs
-        uses: Bugs5382/typedoc-pages-action@v0
+        uses: Bugs5382/typedoc-pages-action@v0.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Pin `Bugs5382/typedoc-pages-action` to `@v0.1.0` in `action-docs.yaml`.

## Why
`@v0` failed to resolve ("unable to find version v0") — the action repo only publishes `v0.1.0`; no floating `@v0` tag exists yet.

## Verification
- Dispatched after merge to confirm the gh-pages docs publish.