### PR TITLE
revert: pin package.json back to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Fastify HL7
 
-## v4.0.1 - 2026-06-08
-
-### What Changed 👀
-
-### Extra
-
-**Full Changelog**: https://github.com/Bugs5382/fastify-hl7/compare/v4.0.0...v4.0.1
-
 ## v4.0.0 - 2026-06-08
 
 ### What Changed 👀
+
+- fix(ci): skip PR Body check for Dependabot @Bugs5382 (#105)
 
 #### 💥 Breaking Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-hl7",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "A Fastify HL7 Plugin Developed in Pure TypeScript.",
   "type": "module",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## What
Restore `package.json` (4.0.1 -> 4.0.0) and `CHANGELOG.md` to the published 4.0.0 release state.

## Why
The Release Manager bumped to 4.0.1 on post-release merges that carried no releasable changes, leaving `main` ahead of the published 4.0.0. This realigns main with the release.

## Note
The merge is made with a CI-skip so the Release Manager does not immediately re-bump. A follow-up will stop the Release Manager from bumping when there are no releasable changes since the last release.