### PR TITLE
ci: bump typedoc-pages-action to v0.1.1

### DIFF
--- a/.github/workflows/action-docs.yaml
+++ b/.github/workflows/action-docs.yaml
@@ -26,6 +26,6 @@ jobs:
         run: npm install --package-lock-only --ignore-scripts --legacy-peer-deps
 
       - name: Publish versioned docs
-        uses: Bugs5382/typedoc-pages-action@v0.1.0
+        uses: Bugs5382/typedoc-pages-action@v0.1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Bump the docs workflow pin in `.github/workflows/action-docs.yaml` from the v0.1.0 tag to the v0.1.1 tag of `Bugs5382/typedoc-pages-action`.

## Why

The v0.1.1 release carries the alias-strip fix. With v0.1.0 the versioned docs publish failed with an EEXIST symlink error, so gh-pages never updated.

## Verification

- Single-line pin change; `ruby -ryaml` loads the workflow cleanly.
- After merge, dispatch the docs workflow against main and confirm the Publish Docs job succeeds.