### PR TITLE
fix(ci): gate the Release Manager bump on releasable changes

### DIFF
--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -57,10 +57,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🔎 Detect releasable changes
+        id: releasable
+        env:
+          BODY: ${{ steps.drafter.outputs.body }}
+        run: |
+          # release-drafter's body lists the categorized PRs since the last
+          # release. With nothing to release (every change excluded, e.g.
+          # skip-changelog), it carries no PR entries -- skip the bump/changelog/
+          # commit so the manifest stays at the published version instead of
+          # drifting ahead.
+          if printf '%s' "$BODY" | grep -qE '\(#[0-9]+\)'; then
+            echo "yes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No releasable changes since the last release; skipping the prep commit."
+            echo "yes=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🔢 Bump Package Version
+        if: steps.releasable.outputs.yes == 'true'
         run: npm version "v${{ steps.drafter.outputs.resolved_version }}" --no-git-tag-version --allow-same-version
 
       - name: 📤 Run Changelog Action
+        if: steps.releasable.outputs.yes == 'true'
         uses: bugs5382/changelog-updater-action@v0.3.2
         with:
           tag: v${{ steps.drafter.outputs.resolved_version }}
@@ -69,6 +88,7 @@ jobs:
           diff: 'true'
 
       - name: 📤 Commit and Push Version Update
+        if: steps.releasable.outputs.yes == 'true'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(pre-release): v${{ steps.drafter.outputs.resolved_version }} [skip ci]"


### PR DESCRIPTION
## What
Apply the Release Manager gate from project-template #23 to this repo's `job-version-bump.yaml`: bump/changelog/commit run only when release-drafter found releasable PRs since the last release. Preserves `workflow_dispatch`.

## Why
The Release Manager bumped `package.json` (4.0.0 -> 4.0.1) on post-release ci/docs merges with nothing to release, drifting the manifest ahead of the published version.

## Verification
- YAML parses. A push whose only changes are excluded no longer bumps; a real feat/fix still preps the next version.